### PR TITLE
Integrate backend template system with dynamic API

### DIFF
--- a/content.js
+++ b/content.js
@@ -109,8 +109,8 @@
       this.maxRetries = 2;
       this.defaultSettings = {
         extensionEnabled: true,
-        narrativeStyle: 'default',
-        webSearchEnabled: false
+        template_id: '3_tier_consumer_friendly_locked_v3', // API default
+        enable_web_search: false
       };
     }
 
@@ -137,11 +137,13 @@
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), this.timeout);
 
-        // Prepare request body with settings
+        // Prepare request body with settings (backward compatible)
         const requestBody = {
           query,
-          narrativeStyle: settings.narrativeStyle,
-          webSearchEnabled: settings.webSearchEnabled
+          template_id: settings.template_id || settings.narrativeStyle || this.defaultSettings.template_id,
+          enable_web_search: settings.enable_web_search !== undefined
+            ? settings.enable_web_search
+            : (settings.webSearchEnabled !== undefined ? settings.webSearchEnabled : this.defaultSettings.enable_web_search)
         };
 
         const response = await fetch(apiUrl, {

--- a/popup.html
+++ b/popup.html
@@ -39,11 +39,11 @@
       <!-- Divider -->
       <div class="settings-divider"></div>
 
-      <!-- Narrative Style Dropdown -->
+      <!-- Template Dropdown -->
       <div class="form-group">
-        <label for="narrativeStyle">Narrative Style:</label>
-        <select id="narrativeStyle" class="form-control">
-          <option value="">Loading...</option>
+        <label for="templateSelect">Template:</label>
+        <select id="templateSelect" class="form-control">
+          <option value="">Loading templates...</option>
         </select>
       </div>
 

--- a/popup.js
+++ b/popup.js
@@ -5,7 +5,7 @@ const HEALTH_CHECK_INTERVAL = 30000; // 30 seconds
 
 // DOM Elements
 let extensionEnabledToggle;
-let narrativeStyleSelect;
+let templateSelect;
 let webSearchToggle;
 let saveButton;
 let statusMessage;
@@ -13,11 +13,15 @@ let healthDot;
 let healthText;
 let healthCheckInterval;
 
+// Templates data
+let availableTemplates = [];
+let defaultTemplateId = null;
+
 // Default settings
 const DEFAULT_SETTINGS = {
   extensionEnabled: true,
-  narrativeStyle: 'default',
-  webSearchEnabled: false
+  template_id: null, // Will be set from API default
+  enable_web_search: false
 };
 
 // Initialize popup
@@ -26,18 +30,18 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Get DOM elements
   extensionEnabledToggle = document.getElementById('extensionEnabled');
-  narrativeStyleSelect = document.getElementById('narrativeStyle');
+  templateSelect = document.getElementById('templateSelect');
   webSearchToggle = document.getElementById('webSearch');
   saveButton = document.getElementById('saveSettings');
   statusMessage = document.getElementById('statusMessage');
   healthDot = document.getElementById('healthDot');
   healthText = document.getElementById('healthText');
 
+  // Load templates from API first
+  await loadTemplates();
+
   // Load saved settings
   await loadSettings();
-
-  // Load narrative styles from API (placeholder for now)
-  await loadNarrativeStyles();
 
   // Start health check
   checkHealth();
@@ -47,10 +51,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   saveButton.addEventListener('click', saveSettings);
   extensionEnabledToggle.addEventListener('change', () => {
     hideStatusMessage();
-    // Update UI state when master toggle changes
     updateFormState();
   });
-  narrativeStyleSelect.addEventListener('change', () => hideStatusMessage());
+  templateSelect.addEventListener('change', () => {
+    hideStatusMessage();
+    onTemplateChange();
+  });
   webSearchToggle.addEventListener('change', () => hideStatusMessage());
 
   // Initialize form state
@@ -68,14 +74,25 @@ window.addEventListener('unload', () => {
 async function loadSettings() {
   try {
     const result = await chrome.storage.sync.get(['hxSettings']);
-    const settings = result.hxSettings || DEFAULT_SETTINGS;
+    const settings = result.hxSettings || {};
 
     console.log('Loaded settings:', settings);
 
-    // Apply settings to UI
+    // Apply settings to UI with backward compatibility
     extensionEnabledToggle.checked = settings.extensionEnabled !== undefined ? settings.extensionEnabled : DEFAULT_SETTINGS.extensionEnabled;
-    narrativeStyleSelect.value = settings.narrativeStyle || DEFAULT_SETTINGS.narrativeStyle;
-    webSearchToggle.checked = settings.webSearchEnabled || DEFAULT_SETTINGS.webSearchEnabled;
+
+    // Use template_id if available, otherwise use default from API
+    const templateId = settings.template_id || defaultTemplateId || DEFAULT_SETTINGS.template_id;
+    templateSelect.value = templateId;
+
+    // Use enable_web_search if available, otherwise fallback to old field name for backward compatibility
+    const webSearchEnabled = settings.enable_web_search !== undefined
+      ? settings.enable_web_search
+      : (settings.webSearchEnabled !== undefined ? settings.webSearchEnabled : DEFAULT_SETTINGS.enable_web_search);
+    webSearchToggle.checked = webSearchEnabled;
+
+    // Update web search toggle state based on selected template
+    onTemplateChange();
   } catch (error) {
     console.error('Error loading settings:', error);
     showStatusMessage('Failed to load settings', 'error');
@@ -90,8 +107,8 @@ async function saveSettings() {
 
     const settings = {
       extensionEnabled: extensionEnabledToggle.checked,
-      narrativeStyle: narrativeStyleSelect.value,
-      webSearchEnabled: webSearchToggle.checked
+      template_id: templateSelect.value,
+      enable_web_search: webSearchToggle.checked
     };
 
     await chrome.storage.sync.set({ hxSettings: settings });
@@ -114,34 +131,98 @@ async function saveSettings() {
 }
 
 // Load narrative styles (placeholder - will be replaced with API call)
-async function loadNarrativeStyles() {
+// Load templates from API
+async function loadTemplates() {
   try {
-    // TODO: Replace with actual API endpoint when provided
-    // For now, use placeholder options
-    const narrativeStyles = [
-      { value: 'default', label: 'Default' },
-      { value: 'detailed', label: 'Detailed Analysis' },
-      { value: 'concise', label: 'Concise Summary' },
-      { value: 'comparative', label: 'Comparative' }
-    ];
+    console.log('Fetching templates from API...');
 
-    // Populate dropdown
-    narrativeStyleSelect.innerHTML = '';
-    narrativeStyles.forEach(style => {
-      const option = document.createElement('option');
-      option.value = style.value;
-      option.textContent = style.label;
-      narrativeStyleSelect.appendChild(option);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(`${API_BASE_URL}/api/templates`, {
+      signal: controller.signal
     });
 
-    // Restore selected value
-    const result = await chrome.storage.sync.get(['hxSettings']);
-    const settings = result.hxSettings || DEFAULT_SETTINGS;
-    narrativeStyleSelect.value = settings.narrativeStyle || DEFAULT_SETTINGS.narrativeStyle;
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    console.log('Templates loaded:', data);
+
+    availableTemplates = data.templates || [];
+    defaultTemplateId = data.default || null;
+
+    // Update DEFAULT_SETTINGS with API default
+    if (defaultTemplateId) {
+      DEFAULT_SETTINGS.template_id = defaultTemplateId;
+    }
+
+    // Populate dropdown
+    templateSelect.innerHTML = '';
+    if (availableTemplates.length === 0) {
+      templateSelect.innerHTML = '<option value="">No templates available</option>';
+      showStatusMessage('No templates available from API', 'error');
+      return;
+    }
+
+    availableTemplates.forEach(template => {
+      const option = document.createElement('option');
+      option.value = template.id;
+      option.textContent = template.name;
+      option.title = template.description;
+      templateSelect.appendChild(option);
+    });
+
+    console.log(`✅ Loaded ${availableTemplates.length} templates`);
 
   } catch (error) {
-    console.error('Error loading narrative styles:', error);
-    narrativeStyleSelect.innerHTML = '<option value="default">Default</option>';
+    console.error('Error loading templates:', error);
+
+    // Fallback to hardcoded defaults
+    templateSelect.innerHTML = '<option value="">Failed to load templates</option>';
+    showStatusMessage('Failed to load templates from API', 'error');
+
+    // Use fallback templates
+    availableTemplates = [
+      {
+        id: '3_tier_consumer_friendly_locked_v3',
+        name: 'Consumer-Friendly Narrative',
+        description: 'Consumer-friendly narrative response',
+        supports_web_search: true
+      }
+    ];
+    defaultTemplateId = '3_tier_consumer_friendly_locked_v3';
+    DEFAULT_SETTINGS.template_id = defaultTemplateId;
+
+    templateSelect.innerHTML = `<option value="${defaultTemplateId}">Consumer-Friendly Narrative (Fallback)</option>`;
+  }
+}
+
+// Handle template selection change
+function onTemplateChange() {
+  const selectedTemplateId = templateSelect.value;
+  const selectedTemplate = availableTemplates.find(t => t.id === selectedTemplateId);
+
+  if (!selectedTemplate) {
+    console.warn('Selected template not found:', selectedTemplateId);
+    return;
+  }
+
+  console.log('Template changed to:', selectedTemplate.name);
+
+  // Update web search toggle based on template support
+  if (selectedTemplate.supports_web_search) {
+    webSearchToggle.disabled = false;
+    webSearchToggle.parentElement.parentElement.style.opacity = '1';
+    webSearchToggle.parentElement.parentElement.title = '';
+  } else {
+    webSearchToggle.disabled = true;
+    webSearchToggle.checked = false;
+    webSearchToggle.parentElement.parentElement.style.opacity = '0.5';
+    webSearchToggle.parentElement.parentElement.title = 'This template does not support web search';
   }
 }
 
@@ -200,15 +281,16 @@ function updateFormState() {
   const isEnabled = extensionEnabledToggle.checked;
 
   // Disable/enable other settings when extension is off
-  narrativeStyleSelect.disabled = !isEnabled;
-  webSearchToggle.disabled = !isEnabled;
+  templateSelect.disabled = !isEnabled;
 
   // Visual feedback
   if (!isEnabled) {
-    narrativeStyleSelect.style.opacity = '0.5';
+    templateSelect.style.opacity = '0.5';
+    webSearchToggle.disabled = true;
     webSearchToggle.parentElement.parentElement.style.opacity = '0.5';
   } else {
-    narrativeStyleSelect.style.opacity = '1';
-    webSearchToggle.parentElement.parentElement.style.opacity = '1';
+    templateSelect.style.opacity = '1';
+    // Let onTemplateChange handle web search toggle state based on template
+    onTemplateChange();
   }
 }


### PR DESCRIPTION
## Summary
Integrate with new backend template system to replace hardcoded narrative styles with dynamic template fetching from API.

## Changes

### Backend API Integration
- Call `GET /api/templates` to fetch available templates on popup load
- Use backend-provided default template
- Send `template_id` and `enable_web_search` to API instead of old field names

### Template Selection
- Replace hardcoded "Narrative Style" dropdown with dynamic templates from API
- Display template name and description from backend
- Graceful error handling with fallback to default template

### Conditional Web Search Toggle
- Web search toggle now respects `supports_web_search` flag from each template
- Automatically disables when template doesn't support web search
- Visual feedback: dimmed UI and tooltip explaining why it's disabled
- Auto-unchecks when switching to incompatible template

### Field Name Updates
- `narrativeStyle` → `template_id`
- `webSearchEnabled` → `enable_web_search`
- Backward compatible with existing user settings

### Error Handling
- 5 second timeout for template fetch
- Fallback to hardcoded default on API failure
- User-friendly error messages
- Extension remains functional even if API unavailable

## API Changes Used

**New Endpoint:**
```
GET /api/templates
```

**Response:**
```json
{
  "templates": [
    {
      "id": "3_tier_consumer_friendly_locked_v3",
      "name": "Consumer-Friendly Narrative",
      "description": "...",
      "supports_web_search": true
    }
  ],
  "default": "3_tier_consumer_friendly_locked_v3"
}
```

**Updated Request:**
```json
{
  "query": "...",
  "template_id": "3_tier_consumer_friendly_locked_v3",
  "enable_web_search": true
}
```

## Testing
1. Reload extension
2. Open settings popup
3. Verify templates load from API
4. Select template without web search support (e.g., "Data-Focused Report")
5. Verify web search toggle becomes disabled and dimmed
6. Select template with web search support
7. Verify web search toggle becomes enabled
8. Save settings and make a query
9. Check network tab to verify correct `template_id` and `enable_web_search` sent to backend